### PR TITLE
Wip/make link cards reusable

### DIFF
--- a/src/components/CreateLinksCard/CreateLinksCard.module.scss
+++ b/src/components/CreateLinksCard/CreateLinksCard.module.scss
@@ -31,3 +31,7 @@
 		background-color: variables.$white;
 	}
 }
+
+.existing_project {
+	border: 1px solid variables.$purple;
+}

--- a/src/components/CreateLinksCard/CreateLinksCard.tsx
+++ b/src/components/CreateLinksCard/CreateLinksCard.tsx
@@ -10,6 +10,8 @@ interface CreateLinksCardProps {
 	errors?: FieldErrors<ProjectErrors> | undefined;
 	register?: UseFormRegister<TCreateLinksValues>;
 	existingProject?: Project;
+	existingProjectIdx?: number;
+	handleDelete?: (project: Project) => void;
 }
 
 const CreateLinksCard = ({
@@ -18,12 +20,26 @@ const CreateLinksCard = ({
 	errors,
 	register,
 	existingProject: initialProjectData,
+	existingProjectIdx,
+	handleDelete,
 }: CreateLinksCardProps) => {
 	return (
-		<div className={styles.create_links_card}>
+		<div
+			className={
+				initialProjectData
+					? `${styles.create_links_card} ${styles.existing_project}`
+					: `${styles.create_links_card}`
+			}
+		>
 			<div>
-				<span>link #{`${cardIndex + 1}`}</span>
-				<button onClick={() => remove?.(cardIndex)}>remove</button>
+				<span>link #{`${existingProjectIdx || cardIndex + 1}`}</span>
+				{handleDelete && initialProjectData ? (
+					<button onClick={() => handleDelete?.(initialProjectData)}>
+						delete
+					</button>
+				) : (
+					<button onClick={() => remove?.(cardIndex)}>remove</button>
+				)}
 			</div>
 			<TextField
 				label='Project name'
@@ -31,7 +47,6 @@ const CreateLinksCard = ({
 				placeholder='Enter the name of your project'
 				inputContainerClassName={styles.create_links_card__textfields}
 				{...(register && register(`projects.${cardIndex}.project_name`))}
-				// {...register(`projects.${cardIndex}.project_name`)}
 				error={errors?.project_name}
 				value={initialProjectData?.project_name}
 			/>
@@ -41,7 +56,6 @@ const CreateLinksCard = ({
 				placeholder='e.g. https//www.github.com/project'
 				inputContainerClassName={styles.create_links_card__textfields}
 				{...(register && register(`projects.${cardIndex}.project_url`))}
-				// {...register(`projects.${cardIndex}.project_url`)}
 				error={errors?.project_url}
 				value={initialProjectData?.project_url}
 			/>

--- a/src/components/CreateLinksCard/CreateLinksCard.tsx
+++ b/src/components/CreateLinksCard/CreateLinksCard.tsx
@@ -2,17 +2,14 @@ import styles from "./CreateLinksCard.module.scss";
 import { FieldErrors, UseFormRegister } from "react-hook-form";
 import TextField from "../common/TextField/TextField";
 import { TCreateLinksValues } from "../../zod";
-
-interface ProjectErrors {
-	project_name: string;
-	project_url: string;
-}
+import { Project, ProjectErrors } from "../../types";
 
 interface CreateLinksCardProps {
 	cardIndex: number;
-	remove: (index?: number | number[]) => void;
-	errors: FieldErrors<ProjectErrors> | undefined;
-	register: UseFormRegister<TCreateLinksValues>;
+	remove?: (index?: number | number[]) => void;
+	errors?: FieldErrors<ProjectErrors> | undefined;
+	register?: UseFormRegister<TCreateLinksValues>;
+	existingProject?: Project;
 }
 
 const CreateLinksCard = ({
@@ -20,28 +17,33 @@ const CreateLinksCard = ({
 	remove,
 	errors,
 	register,
+	existingProject: initialProjectData,
 }: CreateLinksCardProps) => {
 	return (
 		<div className={styles.create_links_card}>
 			<div>
 				<span>link #{`${cardIndex + 1}`}</span>
-				<button onClick={() => remove(cardIndex)}>remove</button>
+				<button onClick={() => remove?.(cardIndex)}>remove</button>
 			</div>
 			<TextField
 				label='Project name'
 				iconVariant='zap'
 				placeholder='Enter the name of your project'
 				inputContainerClassName={styles.create_links_card__textfields}
-				{...register(`projects.${cardIndex}.project_name`)}
+				{...(register && register(`projects.${cardIndex}.project_name`))}
+				// {...register(`projects.${cardIndex}.project_name`)}
 				error={errors?.project_name}
+				value={initialProjectData?.project_name}
 			/>
 			<TextField
 				label='Link'
 				iconVariant='link'
 				placeholder='e.g. https//www.github.com/project'
 				inputContainerClassName={styles.create_links_card__textfields}
-				{...register(`projects.${cardIndex}.project_url`)}
+				{...(register && register(`projects.${cardIndex}.project_url`))}
+				// {...register(`projects.${cardIndex}.project_url`)}
 				error={errors?.project_url}
+				value={initialProjectData?.project_url}
 			/>
 		</div>
 	);

--- a/src/components/common/TextField/TextField.tsx
+++ b/src/components/common/TextField/TextField.tsx
@@ -13,6 +13,7 @@ interface TextFieldProps {
 	inputClassName?: string;
 	labelClassName?: string;
 	inputContainerClassName?: string;
+	value?: string;
 }
 
 const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
@@ -27,6 +28,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 			inputClassName,
 			labelClassName,
 			inputContainerClassName,
+			value,
 			...props
 		},
 		ref
@@ -51,6 +53,8 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 							{...props}
 							type={type}
 							placeholder={placeholder}
+							value={value}
+							disabled={!!value}
 						/>
 						{error?.message && (
 							<small className={styles.error_message}>{error.message}</small>

--- a/src/pages/Dashboard/AddLinks/AddLinks.tsx
+++ b/src/pages/Dashboard/AddLinks/AddLinks.tsx
@@ -43,14 +43,6 @@ const AddLinks = () => {
 
 			const json = await results.json();
 			setProjects(json.projects);
-			// append(
-			// 	json.projects.map((project: Project) => {
-			// 		return {
-			// 			project_name: project.project_name,
-			// 			project_url: project.project_url,
-			// 		};
-			// 	})
-			// );
 		};
 
 		getProjects();
@@ -87,6 +79,10 @@ const AddLinks = () => {
 		}
 	};
 
+	const handleDelete = async (project: Project) => {
+		console.log("project: ", project);
+	};
+
 	return (
 		<DashboardLayout>
 			<div className={styles.dashboard}>
@@ -105,8 +101,12 @@ const AddLinks = () => {
 					<ul ref={ulRef}>
 						{projects.map((project, idx) => {
 							return (
-								<li key={`${project.project_url} unique id`}>
-									<CreateLinksCard existingProject={project} cardIndex={idx} />
+								<li key={`${project.id}`}>
+									<CreateLinksCard
+										existingProject={project}
+										cardIndex={idx}
+										handleDelete={handleDelete}
+									/>
 								</li>
 							);
 						})}
@@ -117,9 +117,10 @@ const AddLinks = () => {
 										<li key={field.id}>
 											<CreateLinksCard
 												cardIndex={index}
-												remove={remove}
 												errors={errors.projects?.[index]}
+												existingProjectIdx={projects.length + index + 1}
 												register={register}
+												remove={remove}
 											/>
 										</li>
 									);

--- a/src/pages/Dashboard/AddLinks/AddLinks.tsx
+++ b/src/pages/Dashboard/AddLinks/AddLinks.tsx
@@ -7,47 +7,10 @@ import { TCreateLinksValues, createLinkSchema } from "../model";
 import Button from "../../../components/common/Button/Button";
 import CreateLinksCard from "../../../components/CreateLinksCard/CreateLinksCard";
 import DashboardLayout from "../DashboardLayout";
-
-interface Project {
-	project_name: string;
-	project_url: string;
-}
+import { Project } from "../../../types";
 
 const AddLinks = () => {
 	const [projects, setProjects] = useState<Project[]>([]);
-
-	useEffect(() => {
-		const getProjects = async () => {
-			let url = import.meta.env.DEV
-				? import.meta.env.VITE_DEV_API
-				: import.meta.env.VITE_PROD_URL;
-
-			const token = localStorage.getItem("foliolinks_access_token");
-			const results = await fetch(`${url}/api/users/projects`, {
-				method: "get",
-				headers: {
-					Authorization: `Bearer ${token}`,
-				},
-			});
-			const json = await results.json();
-
-			if (json.projects.length) {
-				setProjects(json.projects);
-
-				append(
-					projects.map((project: Project) => {
-						return {
-							project_name: project.project_name,
-							project_url: project.project_url,
-						};
-					})
-				);
-			}
-		};
-
-		getProjects();
-	}, [projects.length]);
-
 	const ulRef = useRef<HTMLUListElement | null>(null);
 
 	const {
@@ -64,6 +27,35 @@ const AddLinks = () => {
 		control,
 	});
 
+	useEffect(() => {
+		const getProjects = async () => {
+			const url = import.meta.env.DEV
+				? import.meta.env.VITE_DEV_API
+				: import.meta.env.VITE_PROD_URL;
+
+			const token = localStorage.getItem("foliolinks_access_token");
+			const results = await fetch(`${url}/api/users/projects`, {
+				method: "get",
+				headers: {
+					Authorization: `Bearer ${token}`,
+				},
+			});
+
+			const json = await results.json();
+			setProjects(json.projects);
+			// append(
+			// 	json.projects.map((project: Project) => {
+			// 		return {
+			// 			project_name: project.project_name,
+			// 			project_url: project.project_url,
+			// 		};
+			// 	})
+			// );
+		};
+
+		getProjects();
+	}, [append]);
+
 	const handleAddNewLink = () => {
 		flushSync(() => {
 			append({ project_name: "", project_url: "" });
@@ -75,7 +67,7 @@ const AddLinks = () => {
 	const handleSave = async (data: TCreateLinksValues) => {
 		console.log("data: ", data);
 		try {
-			let url = import.meta.env.DEV
+			const url = import.meta.env.DEV
 				? import.meta.env.VITE_DEV_API
 				: import.meta.env.VITE_PROD_URL;
 			const token = localStorage.getItem("foliolinks_access_token");
@@ -111,7 +103,14 @@ const AddLinks = () => {
 
 				<section className={styles.dashboard_create__container}>
 					<ul ref={ulRef}>
-						{fields.length ? (
+						{projects.map((project, idx) => {
+							return (
+								<li key={`${project.project_url} unique id`}>
+									<CreateLinksCard existingProject={project} cardIndex={idx} />
+								</li>
+							);
+						})}
+						{fields.length || projects.length ? (
 							<>
 								{fields.map((field, index) => {
 									return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 export interface Project {
+	id: string;
 	project_name: string;
 	project_url: string;
+	username: string;
 }
 
 export interface ProjectErrors {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export interface Project {
+	project_name: string;
+	project_url: string;
+}
+
+export interface ProjectErrors {
+	project_name: string;
+	project_url: string;
+}


### PR DESCRIPTION
# description

Link cards are used for both read and creation, but currently function the same. We want them to be populated and disabled when reading projects

# ac

- [x] prepopulate fields when reading projects
- [x] disable fields if fields are coming from db