### PR TITLE
Wip/32 fix move useauth to a global context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,16 @@
+import { useContext, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "./hooks/useAuth";
+import { AuthContext } from "./contexts/AuthContext";
 
 function App() {
-	const isAuth = useAuth();
 	const navigate = useNavigate();
+	const { isAuthenticated } = useContext(AuthContext);
 
-	if (isAuth) {
-		navigate("/dashboard");
-	}
+	useEffect(() => {
+		if (isAuthenticated) {
+			navigate("/dashboard");
+		}
+	}, [isAuthenticated, navigate]);
 
 	return (
 		<>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,129 @@
+import {
+	createContext,
+	ReactNode,
+	useCallback,
+	useEffect,
+	useState,
+} from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { jwtDecode } from "jwt-decode";
+
+interface AuthContextType {
+	isAuthenticated: boolean;
+}
+
+export const AuthContext = createContext<AuthContextType>({
+	isAuthenticated: false,
+});
+
+const authRoutes = ["/login", "/register"];
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+	const [isAuthenticated, setIsAuthenticated] = useState(false);
+	const navigate = useNavigate();
+	const location = useLocation();
+	const access_token = localStorage.getItem("foliolinks_access_token");
+
+	const refreshAccessToken = useCallback(async () => {
+		try {
+			const url = import.meta.env.DEV
+				? import.meta.env.VITE_DEV_API
+				: import.meta.env.VITE_PROD_URL;
+
+			const result = await fetch(`${url}/api/users/auth/refresh`, {
+				method: "POST",
+				credentials: "include",
+			});
+
+			const json = await result.json();
+
+			if (json?.status === 400) {
+				throw Error(json.name);
+			} else {
+				localStorage.setItem("foliolinks_access_token", json.access_token);
+				setIsAuthenticated(true);
+				navigate(location.pathname);
+			}
+		} catch (error) {
+			console.log("refresh error: ", error);
+			navigate("/login");
+		}
+	}, [location.pathname, navigate]);
+
+	/**
+	 * When application mounts:
+	 * - check if access token is present
+	 * - if not, redirects to login page
+	 * - if present, decode and check if token is expired:
+	 * 		- if not expired, set is auth to true
+	 * 		- if expired, run refresh access token function
+	 */
+	useEffect(() => {
+		if (!access_token) {
+			if (authRoutes.includes(location.pathname)) {
+				navigate(location.pathname);
+				return;
+			}
+
+			setIsAuthenticated(false);
+			navigate("/login");
+			return;
+		}
+
+		const { exp } = jwtDecode(access_token) as { exp: number };
+		const expiryDate = new Date(exp * 1000);
+		const currentDate = new Date();
+		const isExpired = currentDate > expiryDate;
+
+		if (!isExpired) {
+			setIsAuthenticated(true);
+			return;
+		}
+
+		if (isExpired) {
+			refreshAccessToken();
+		}
+	}, [
+		access_token,
+		navigate,
+		setIsAuthenticated,
+		refreshAccessToken,
+		location.pathname,
+	]);
+
+	/**
+	 * Hide Login and Register pages if user is already authenticated by always navigating to Dashboard page if conditions are met
+	 */
+	useEffect(() => {
+		if (isAuthenticated && authRoutes.includes(location.pathname)) {
+			navigate("/dashboard");
+		}
+
+		if (!access_token) return;
+
+		const { exp } = jwtDecode(access_token) as { exp: number };
+		const expiryDate = new Date(exp * 1000);
+		const tenMinutesInMs = 10 * 60 * 1000;
+		const tenMinBeforeExpiry = expiryDate.getTime() - tenMinutesInMs;
+		const delay = Math.max(0, tenMinBeforeExpiry - Date.now());
+
+		const silentRefreshTimeout = setTimeout(async () => {
+			await refreshAccessToken();
+		}, delay);
+		return () => {
+			clearTimeout(silentRefreshTimeout);
+		};
+	}, [
+		isAuthenticated,
+		location.pathname,
+		access_token,
+		navigate,
+		refreshAccessToken,
+	]);
+
+	return (
+		<AuthContext.Provider value={{ isAuthenticated }}>
+			{children}
+		</AuthContext.Provider>
+	);
+};

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,111 +1,111 @@
-import { useState, useEffect, useCallback } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { jwtDecode } from "jwt-decode";
+// import { useState, useEffect, useCallback } from "react";
+// import { useLocation, useNavigate } from "react-router-dom";
+// import { jwtDecode } from "jwt-decode";
 
-const authRoutes = ["/login", "/register"];
+// const authRoutes = ["/login", "/register"];
 
-export const useAuth = () => {
-	const [isAuthenticated, setIsAuthenticated] = useState(false);
-	const navigate = useNavigate();
-	const location = useLocation();
-	const access_token = localStorage.getItem("foliolinks_access_token");
+// export const useAuth = () => {
+// 	const [isAuthenticated, setIsAuthenticated] = useState(false);
+// 	const navigate = useNavigate();
+// 	const location = useLocation();
+// 	const access_token = localStorage.getItem("foliolinks_access_token");
 
-	const refreshAccessToken = useCallback(async () => {
-		try {
-			const url = import.meta.env.DEV
-				? import.meta.env.VITE_DEV_API
-				: import.meta.env.VITE_PROD_URL;
+// 	const refreshAccessToken = useCallback(async () => {
+// 		try {
+// 			const url = import.meta.env.DEV
+// 				? import.meta.env.VITE_DEV_API
+// 				: import.meta.env.VITE_PROD_URL;
 
-			const result = await fetch(`${url}/api/users/auth/refresh`, {
-				method: "POST",
-				credentials: "include",
-			});
+// 			const result = await fetch(`${url}/api/users/auth/refresh`, {
+// 				method: "POST",
+// 				credentials: "include",
+// 			});
 
-			const json = await result.json();
+// 			const json = await result.json();
 
-			if (json?.status === 400) {
-				throw Error(json.name);
-			} else {
-				localStorage.setItem("foliolinks_access_token", json.access_token);
-				setIsAuthenticated(true);
-				navigate(location.pathname);
-			}
-		} catch (error) {
-			console.log("refresh error: ", error);
-			navigate("/login");
-		}
-	}, [location.pathname, navigate]);
+// 			if (json?.status === 400) {
+// 				throw Error(json.name);
+// 			} else {
+// 				localStorage.setItem("foliolinks_access_token", json.access_token);
+// 				setIsAuthenticated(true);
+// 				navigate(location.pathname);
+// 			}
+// 		} catch (error) {
+// 			console.log("refresh error: ", error);
+// 			navigate("/login");
+// 		}
+// 	}, [location.pathname, navigate]);
 
-	/**
-	 * When application mounts:
-	 * - check if access token is present
-	 * - if not, redirects to login page
-	 * - if present, decode and check if token is expired:
-	 * 		- if not expired, set is auth to true
-	 * 		- if expired, run refresh access token function
-	 */
-	useEffect(() => {
-		if (!access_token) {
-			if (authRoutes.includes(location.pathname)) {
-				navigate(location.pathname);
-				return;
-			}
+// 	/**
+// 	 * When application mounts:
+// 	 * - check if access token is present
+// 	 * - if not, redirects to login page
+// 	 * - if present, decode and check if token is expired:
+// 	 * 		- if not expired, set is auth to true
+// 	 * 		- if expired, run refresh access token function
+// 	 */
+// 	useEffect(() => {
+// 		if (!access_token) {
+// 			if (authRoutes.includes(location.pathname)) {
+// 				navigate(location.pathname);
+// 				return;
+// 			}
 
-			setIsAuthenticated(false);
-			navigate("/login");
-			return;
-		}
+// 			setIsAuthenticated(false);
+// 			navigate("/login");
+// 			return;
+// 		}
 
-		const { exp } = jwtDecode(access_token) as { exp: number };
-		const expiryDate = new Date(exp * 1000);
-		const currentDate = new Date();
-		const isExpired = currentDate > expiryDate;
+// 		const { exp } = jwtDecode(access_token) as { exp: number };
+// 		const expiryDate = new Date(exp * 1000);
+// 		const currentDate = new Date();
+// 		const isExpired = currentDate > expiryDate;
 
-		if (!isExpired) {
-			setIsAuthenticated(true);
-			return;
-		}
+// 		if (!isExpired) {
+// 			setIsAuthenticated(true);
+// 			return;
+// 		}
 
-		if (isExpired) {
-			refreshAccessToken();
-		}
-	}, [
-		access_token,
-		navigate,
-		setIsAuthenticated,
-		refreshAccessToken,
-		location.pathname,
-	]);
+// 		if (isExpired) {
+// 			refreshAccessToken();
+// 		}
+// 	}, [
+// 		access_token,
+// 		navigate,
+// 		setIsAuthenticated,
+// 		refreshAccessToken,
+// 		location.pathname,
+// 	]);
 
-	/**
-	 * Hide Login and Register pages if user is already authenticated by always navigating to Dashboard page if conditions are met
-	 */
-	useEffect(() => {
-		if (isAuthenticated && authRoutes.includes(location.pathname)) {
-			navigate("/dashboard");
-		}
+// 	/**
+// 	 * Hide Login and Register pages if user is already authenticated by always navigating to Dashboard page if conditions are met
+// 	 */
+// 	useEffect(() => {
+// 		if (isAuthenticated && authRoutes.includes(location.pathname)) {
+// 			navigate("/dashboard");
+// 		}
 
-		if (!access_token) return;
+// 		if (!access_token) return;
 
-		const { exp } = jwtDecode(access_token) as { exp: number };
-		const expiryDate = new Date(exp * 1000);
-		const tenMinutesInMs = 10 * 60 * 1000;
-		const tenMinBeforeExpiry = expiryDate.getTime() - tenMinutesInMs;
-		const delay = Math.max(0, tenMinBeforeExpiry - Date.now());
+// 		const { exp } = jwtDecode(access_token) as { exp: number };
+// 		const expiryDate = new Date(exp * 1000);
+// 		const tenMinutesInMs = 10 * 60 * 1000;
+// 		const tenMinBeforeExpiry = expiryDate.getTime() - tenMinutesInMs;
+// 		const delay = Math.max(0, tenMinBeforeExpiry - Date.now());
 
-		const silentRefreshTimeout = setTimeout(async () => {
-			await refreshAccessToken();
-		}, delay);
-		return () => {
-			clearTimeout(silentRefreshTimeout);
-		};
-	}, [
-		isAuthenticated,
-		location.pathname,
-		access_token,
-		navigate,
-		refreshAccessToken,
-	]);
+// 		const silentRefreshTimeout = setTimeout(async () => {
+// 			await refreshAccessToken();
+// 		}, delay);
+// 		return () => {
+// 			clearTimeout(silentRefreshTimeout);
+// 		};
+// 	}, [
+// 		isAuthenticated,
+// 		location.pathname,
+// 		access_token,
+// 		navigate,
+// 		refreshAccessToken,
+// 	]);
 
-	return isAuthenticated;
-};
+// 	return isAuthenticated;
+// };

--- a/src/layout/AuthLayout.tsx
+++ b/src/layout/AuthLayout.tsx
@@ -1,0 +1,12 @@
+import { AuthProvider } from "../contexts/AuthContext";
+import { Outlet } from "react-router-dom";
+
+const AuthLayout = () => {
+	return (
+		<AuthProvider>
+			<Outlet />
+		</AuthProvider>
+	);
+};
+
+export default AuthLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,58 +16,62 @@ import { ProjectsProvider } from "./contexts/ProjectsContext.tsx";
 import CreateUserAccount from "./pages/Auth/Register/CreateUserAccount/CreateUserAccount.tsx";
 import CreateUserInfo from "./pages/Auth/Register/CreateUserProfile/CreateUserProfile.tsx";
 import Preview from "./pages/Dashboard/Preview/Preview.tsx";
+import AuthLayout from "./layout/AuthLayout.tsx";
 
 const queryClient = new QueryClient();
 
 const router = createBrowserRouter([
-	{ path: "*", element: <NotFound /> },
 	{
 		path: "/",
-		element: <App />,
-	},
-	{
-		path: "/dashboard",
-		element: (
-			<ProtectedRoute>
-				<UserProvider>
-					<ProjectsProvider>
-						<AddLinks />
-					</ProjectsProvider>
-				</UserProvider>
-			</ProtectedRoute>
-		),
-	},
-	{
-		path: "/dashboard/profile",
-		element: (
-			<ProtectedRoute>
-				<UserProvider>
-					<ProjectsProvider>
-						<Profile />
-					</ProjectsProvider>
-				</UserProvider>
-			</ProtectedRoute>
-		),
-	},
-	{
-		path: "/dashboard/preview",
-		element: (
-			<ProtectedRoute>
-				<UserProvider>
-					<ProjectsProvider>
-						<Preview />
-					</ProjectsProvider>
-				</UserProvider>
-			</ProtectedRoute>
-		),
-	},
-	{ path: "/login", element: <Login /> },
-	{
-		path: "/register",
-		element: <Register />,
+		element: <AuthLayout />,
 		children: [
-			{ path: "", element: <CreateUserAccount /> },
-			{ path: "userinfo", element: <CreateUserInfo /> },
+			{ path: "*", element: <NotFound /> },
+			{ index: true, element: <App /> },
+			{
+				path: "/dashboard",
+				element: (
+					<ProtectedRoute>
+						<UserProvider>
+							<ProjectsProvider>
+								<AddLinks />
+							</ProjectsProvider>
+						</UserProvider>
+					</ProtectedRoute>
+				),
+			},
+			{
+				path: "/dashboard/profile",
+				element: (
+					<ProtectedRoute>
+						<UserProvider>
+							<ProjectsProvider>
+								<Profile />
+							</ProjectsProvider>
+						</UserProvider>
+					</ProtectedRoute>
+				),
+			},
+			{
+				path: "/dashboard/preview",
+				element: (
+					<ProtectedRoute>
+						<UserProvider>
+							<ProjectsProvider>
+								<Preview />
+							</ProjectsProvider>
+						</UserProvider>
+					</ProtectedRoute>
+				),
+			},
+			{ path: "/login", element: <Login /> },
+			{
+				path: "/register",
+				element: <Register />,
+				children: [
+					{ path: "", element: <CreateUserAccount /> },
+					{ path: "userinfo", element: <CreateUserInfo /> },
+				],
+			},
 		],
 	},
 ]);

--- a/src/pages/Auth/Login/Login.tsx
+++ b/src/pages/Auth/Login/Login.tsx
@@ -7,12 +7,10 @@ import { TLoginFormInputs, loginSchema } from "../model";
 import TextField from "../../../components/common/TextField/TextField";
 import { Button } from "../../../components/common/Button/Button";
 import AuthLayout from "../AuthLayout";
-import { useAuth } from "../../../hooks/useAuth";
 import { useMutation } from "@tanstack/react-query";
 import { handleLoginAPI } from "../../../api/auth";
 
 const Login: FunctionComponent = () => {
-	useAuth();
 	const navigate = useNavigate();
 
 	const {

--- a/src/pages/Auth/Register/CreateUserAccount/CreateUserAccount.tsx
+++ b/src/pages/Auth/Register/CreateUserAccount/CreateUserAccount.tsx
@@ -5,13 +5,11 @@ import { Link, useNavigate } from "react-router-dom";
 import { TRegisterFormInputs, registerSchema } from "../../model";
 import TextField from "../../../../components/common/TextField/TextField";
 import { Button } from "../../../../components/common/Button/Button";
-import { useAuth } from "../../../../hooks/useAuth";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { handleRegisterAPI } from "../../../../api/auth";
 
 const CreateUserAccount = () => {
-	useAuth();
 	const navigate = useNavigate();
 	const {
 		handleSubmit,

--- a/src/pages/Auth/Register/CreateUserProfile/CreateUserProfile.tsx
+++ b/src/pages/Auth/Register/CreateUserProfile/CreateUserProfile.tsx
@@ -5,13 +5,11 @@ import { useNavigate } from "react-router-dom";
 import { TUserInfoInputs, userInfoSchema } from "../../model";
 import TextField from "../../../../components/common/TextField/TextField";
 import { Button } from "../../../../components/common/Button/Button";
-import { useAuth } from "../../../../hooks/useAuth";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { createUserProfileAPI } from "../../../../api/user";
 
 const CreateUserProfile = () => {
-	useAuth();
 	const navigate = useNavigate();
 	const {
 		handleSubmit,

--- a/src/pages/Auth/Register/Register.tsx
+++ b/src/pages/Auth/Register/Register.tsx
@@ -1,11 +1,7 @@
 import { Outlet } from "react-router-dom";
-
 import AuthLayout from "../AuthLayout";
-import { useAuth } from "../../../hooks/useAuth";
 
 const Register = () => {
-	useAuth();
-
 	return (
 		<AuthLayout>
 			<Outlet />

--- a/src/pages/ProtectedRoute.tsx
+++ b/src/pages/ProtectedRoute.tsx
@@ -1,13 +1,10 @@
 import { ReactNode } from "react";
-import { useAuth } from "../hooks/useAuth";
 
 interface Props {
 	children: ReactNode;
 }
 
 const ProtectedRoute = ({ children }: Props) => {
-	useAuth();
-
 	return <>{children}</>;
 };
 


### PR DESCRIPTION
# Goal

Instead of calling useAuth multiple times, wrap your app in an AuthProvider, so that authentication logic is only handled once at the top level.

- useAuth runs inside multiple components simultaneously, leading to race conditions in authentication logic.
- Your useEffect might be trying to access localStorage before it updates properly.
- Calling navigate("/dashboard") directly in App.tsx might be causing unnecessary redirects.

# AC

- [x] Create AuthContext
- [x] Update main.tsx to wrap in AuthProvider
- [x] Remove unnecessary useAuth calls