### PR TITLE
Disable Profile Details

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -30,7 +30,7 @@ export const createUserProfileAPI = async (
 	data: Pick<UserProfile, "username" | "firstName" | "lastName">
 ): Promise<UserProfile | undefined> => {
 	const token = localStorage.getItem("foliolinks_access_token");
-	if (!token) return;
+	// if (!token) return;
 
 	try {
 		const url = import.meta.env.DEV
@@ -45,8 +45,23 @@ export const createUserProfileAPI = async (
 				"Content-Type": "application/json",
 			},
 		});
+
+		if (!result.ok) {
+			let error = `Request failed with status ${result.status}`;
+			try {
+				const errorJson = await result.json();
+				if (error && errorJson) {
+					error = errorJson.error;
+				}
+			} catch (error) {
+				console.log(error);
+			}
+			throw new Error(error);
+		}
+
 		const json = await result.json();
 		if (json.error) throw new Error(json.error);
+
 		return json.data;
 	} catch (error) {
 		if (error instanceof Error) throw new Error(error.message);

--- a/src/pages/Dashboard/model/index.tsx
+++ b/src/pages/Dashboard/model/index.tsx
@@ -41,23 +41,24 @@ export const profileSchema = z.object({
 			if (!files?.length) return true;
 			return files[0]?.size <= MAX_FILE_SIZE;
 		}, "File needs to be 5MB or less"),
-	username: z.string().min(1, { message: "Field is required" }).trim(),
-	firstName: z.string().min(1, { message: "Field is required" }).trim(),
-	lastName: z.string().min(1, { message: "Field is required" }).trim(),
-	email: z
-		.string()
-		.transform((value) => {
-			if (!value) return;
-			return value;
-		})
-		.pipe(
-			z
-				.string()
-				.email({ message: "Invalie email address" })
-				.trim()
-				.toLowerCase()
-				.optional()
-		),
+	username: z.string().trim().min(1, { message: "Field is required" }),
+	firstName: z.string().trim().min(1, { message: "Field is required" }),
+	lastName: z.string().trim().min(1, { message: "Field is required" }),
+	// email: z
+	// 	.string()
+	// 	.optional()
+	// 	.transform((value) => {
+	// 		if (!value) return;
+	// 		return value;
+	// 	})
+	// 	.pipe(
+	// 		z
+	// 			.string()
+	// 			.email({ message: "Invalie email address" })
+	// 			.trim()
+	// 			.toLowerCase()
+	// 			.optional()
+	// 	),
 });
 
 export type TProfileFormValues = z.infer<typeof profileSchema>;


### PR DESCRIPTION
# Goal

Disable form on successful submission. Currently, users who do not have their profile details filled, need to be navigated there to complete it. However, on submission, the form isn't disabled until the page dismounts and mounts again

# AC

- [x] refactor into using mutation
- [x] disable form