### PR TITLE
Move Username Field To Registration

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -40,8 +40,9 @@ export const handleRegisterAPI = async (data: TRegisterFormInputs) => {
 
 	const json = await result.json();
 
-	if (json.error || json.name === "AuthApiError")
-		throw new Error(json.error || json.message);
+	if (json.errorCode) {
+		throw json;
+	}
 
 	const { access_token } = await json;
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -27,7 +27,7 @@ export const getUserProfileAPI = async (): Promise<UserProfile | undefined> => {
 };
 
 export const createUserProfileAPI = async (
-	data: Pick<UserProfile, "username" | "firstName" | "lastName">
+	data: Pick<UserProfile, "firstName" | "lastName">
 ): Promise<UserProfile | undefined> => {
 	const token = localStorage.getItem("foliolinks_access_token");
 	// if (!token) return;

--- a/src/components/common/TextField/TextField.tsx
+++ b/src/components/common/TextField/TextField.tsx
@@ -7,7 +7,7 @@ interface TextFieldProps {
 	label?: string;
 	error?: FieldError;
 	placeholder?: string;
-	iconVariant?: "link" | "mail" | "lock" | "zap";
+	iconVariant?: "link" | "mail" | "lock" | "zap" | "user";
 	type?: "text" | "password" | string;
 	className?: string;
 	inputClassName?: string;

--- a/src/pages/Auth/Register/CreateUserAccount/CreateUserAccount.module.scss
+++ b/src/pages/Auth/Register/CreateUserAccount/CreateUserAccount.module.scss
@@ -17,9 +17,13 @@
 	}
 
 	button {
-		margin-top: 2rem;
 		margin-bottom: 2rem;
-		width: 100%;
+	}
+
+	.register_page__form {
+		display: flex;
+		flex-direction: column;
+		row-gap: 1.5rem;
 	}
 
 	section:last-of-type {
@@ -41,8 +45,4 @@
 		padding-left: 2rem;
 		padding-right: 2rem;
 	}
-}
-
-.form_textfield {
-	margin: 1.5rem 0;
 }

--- a/src/pages/Auth/Register/CreateUserAccount/CreateUserAccount.tsx
+++ b/src/pages/Auth/Register/CreateUserAccount/CreateUserAccount.tsx
@@ -1,12 +1,14 @@
-import styles from "./CreateUserAccount.module.scss";
+import { Link, useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Link, useNavigate } from "react-router-dom";
-import { TRegisterFormInputs, registerSchema } from "../../model";
+import { useMutation } from "@tanstack/react-query";
+
+import styles from "./CreateUserAccount.module.scss";
+
 import TextField from "../../../../components/common/TextField/TextField";
 import { Button } from "../../../../components/common/Button/Button";
-import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
+
+import { TRegisterFormInputs, registerSchema } from "../../model";
 import { handleRegisterAPI } from "../../../../api/auth";
 
 const CreateUserAccount = () => {
@@ -15,19 +17,33 @@ const CreateUserAccount = () => {
 		handleSubmit,
 		register,
 		formState: { errors },
+		setError,
 	} = useForm<TRegisterFormInputs>({
 		resolver: zodResolver(registerSchema),
 	});
-
-	const [error, setError] = useState("");
 
 	const registerMutation = useMutation({
 		mutationFn: handleRegisterAPI,
 		onSuccess: () => {
 			navigate("userinfo");
 		},
-		onError: (error) => {
-			setError(error.message);
+		onError: (error: { error: string; errorCode: string }) => {
+			switch (error.errorCode) {
+				case "USERNAME_TAKEN":
+					setError("username", { message: error.error });
+					break;
+
+				case "SIGNUP_FAILED":
+					setError("email", { message: error.error });
+					break;
+
+				case "AuthApiError":
+					setError("email", { message: error.error });
+					break;
+
+				default:
+					console.log(error);
+			}
 		},
 	});
 
@@ -51,13 +67,19 @@ const CreateUserAccount = () => {
 							onSubmit={handleSubmit(onRegisterSubmit)}
 						>
 							<TextField
+								{...register("username")}
+								error={errors.username}
+								iconVariant='user'
+								label='username'
+								placeholder='alex'
+							/>
+							<TextField
 								{...register("email")}
 								error={errors.email}
 								iconVariant='mail'
 								label='email'
 								placeholder='e.g. alex@email.com'
 							/>
-							{error ? <small style={{ color: "red" }}>{error}</small> : null}
 							<TextField
 								{...register("password")}
 								error={errors.password}
@@ -65,7 +87,6 @@ const CreateUserAccount = () => {
 								type='password'
 								label='password'
 								placeholder='At least 8 characters'
-								className={styles.form_textfield}
 							/>
 							<TextField
 								{...register("confirm_password")}

--- a/src/pages/Auth/Register/CreateUserProfile/CreateUserProfile.tsx
+++ b/src/pages/Auth/Register/CreateUserProfile/CreateUserProfile.tsx
@@ -46,12 +46,6 @@ const CreateUserProfile = () => {
 							className={styles.register_page__form}
 							onSubmit={handleSubmit(handleSubmitUserProfile)}
 						>
-							<TextField
-								{...register("username")}
-								error={errors.username}
-								label='username'
-								placeholder='johndoe'
-							/>
 							{error ? <small style={{ color: "red" }}>{error}</small> : null}
 							<TextField
 								{...register("firstName")}

--- a/src/pages/Auth/model/index.tsx
+++ b/src/pages/Auth/model/index.tsx
@@ -14,6 +14,11 @@ export type TLoginFormInputs = z.infer<typeof loginSchema>;
 
 export const registerSchema = z
 	.object({
+		username: z
+			.string()
+			.min(1, { message: "Can't be empty" })
+			.toLowerCase()
+			.trim(),
 		email: z
 			.string()
 			.min(1, { message: "Can't be empty" })
@@ -36,11 +41,6 @@ export const registerSchema = z
 export type TRegisterFormInputs = z.infer<typeof registerSchema>;
 
 export const userInfoSchema = z.object({
-	username: z
-		.string()
-		.min(1, { message: "Can't be empty" })
-		.toLowerCase()
-		.trim(),
 	firstName: z.string().min(1, { message: "Can't be empty" }).trim(),
 	lastName: z.string().min(1, { message: "Can't be empty" }).trim(),
 });


### PR DESCRIPTION
# Goal

Currently, user can choose their username in step 2 aka user profile setup page step. User should be able to choose their username during account creation / registration

# AC

- [x] Move username input field to Register
- [x] Render potential error messages

- user now picks their username during registration
- switch case to display error msgs at appropriate input fields
- fix typing
- spacing